### PR TITLE
Update js-configmap.yaml

### DIFF
--- a/charts/kashti/templates/js-configmap.yaml
+++ b/charts/kashti/templates/js-configmap.yaml
@@ -8,5 +8,5 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   "settings.js": |-
-    var brigadeApiURL = '{{ default "http://localhost:7744" .Values.brigade.apiServer }}';
+    var brigadeApiURL = '{{ default "http://localhost:7745" .Values.brigade.apiServer }}';
     // End


### PR DESCRIPTION
update the default brigadeAPI server port to 7745. Will not have caused an issue unless someone removed the default from the value.yaml file